### PR TITLE
Add tests, restructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,12 +1,9 @@
 [root]
 name = "reekup"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap 2.22.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-curl 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -27,25 +24,6 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "byteorder"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bytes"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -72,7 +50,7 @@ dependencies = [
  "curl-sys 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -84,15 +62,10 @@ dependencies = [
  "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "futures"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gcc"
@@ -109,15 +82,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,11 +89,6 @@ dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "lazycell"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
@@ -147,57 +106,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "mio"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -213,16 +128,6 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "scoped-tls"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "slab"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "strsim"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,48 +140,6 @@ dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-core"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-curl"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "curl 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-io"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -314,15 +177,6 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "yaml-rust"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,39 +185,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
-"checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
-"checksum bytes 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "46112a0060ae15e3a3f9a445428a53e082b91215b744fa27a1948842f4a64b96"
-"checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum clap 2.22.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e17a4a72ffea176f77d6e2db609c6c919ef221f23862c9915e687fb54d833485"
 "checksum curl 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c90e1240ef340dd4027ade439e5c7c2064dd9dc652682117bd50d1486a3add7b"
 "checksum curl-sys 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d909dc402ae80b6f7b0118c039203436061b9d9a3ca5d2c2546d93e0a61aaa"
-"checksum futures 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8e51e7f9c150ba7fd4cee9df8bf6ea3dea5b63b68955ddad19ccd35b71dcfb4d"
 "checksum gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)" = "40899336fb50db0c78710f53e87afc54d8c7266fb76262fecc78ca1a7f09deae"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
-"checksum iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29d062ee61fccdf25be172e70f34c9f6efc597e1fb8f6526e8437b2046ab26be"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce12306c4739d86ee97c23139f3a34ddf0387bbf181bc7929d287025a8c3ef6b"
 "checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
 "checksum libz-sys 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e5ee912a45d686d393d5ac87fac15ba0ba18daae14e8e7543c63ebf7fb7e970c"
-"checksum log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5141eca02775a762cc6cd564d8d2c50f67c0ea3a372cbf1c51592b3e029e10ad"
-"checksum mio 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f27d38f824a0d267d55b29b171e9e99269a53812e385fa75c1fe700ae254a6a4"
-"checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum net2 0.2.27 (registry+https://github.com/rust-lang/crates.io-index)" = "18b9642ad6222faf5ce46f6966f59b71b9775ad5758c9e09fcf0a6c8061972b4"
 "checksum openssl-probe 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "756d49c8424483a3df3b5d735112b4da22109ced9a8294f1f5cdf80fb3810919"
-"checksum openssl-sys 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "376c5c6084e5ea95eea9c3280801e46d0dcf51251d4f01b747e044fb64d1fb31"
+"checksum openssl-sys 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "14f5bfd12054d764510b887152d564ba11d99ae24ea7d740781778f646620576"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
-"checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
-"checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum term_size 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "07b6c1ac5b3fffd75073276bca1ceed01f67a28537097a2a9539e116e50fb21a"
-"checksum tokio-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "99e958104a67877907c1454386d5482fe8e965a55d60be834a15a44328e7dc76"
-"checksum tokio-curl 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "abc816085f1fe81e04960a50e53a49ac9d2f5b0263c3e52430ad98f77f725f2a"
-"checksum tokio-io 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "48f55df1341bb92281f229a6030bc2abffde2c7a44c6d6b802b7687dd8be0775"
 "checksum unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18127285758f0e2c6cf325bb3f3d138a12fee27de4f23e146cd6a179f26c2cf3"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"
 "checksum vec_map 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8cdc8b93bd0198ed872357fb2e667f7125646b1762f16d60b2c96350d361897"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
-"checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,4 @@ authors = ["Ian Whitney <whit0694@umn.edu>"]
 
 [dependencies]
 curl = "0.4.6"
-futures = "0.1.11"
-tokio-core = "0.1.6"
-tokio-curl = "0.1"
 clap = {version = "2", features = ["yaml"]}

--- a/README.md
+++ b/README.md
@@ -23,4 +23,16 @@ Otherwise, you can compile it yourself
 
 If no `config.reek` file exists, it will be created.
 
-If you run reekup more than once it'll just keep appending to your config.reek file. So...don't do that.
+If a `config.reek` file already exists, the contents of it will be preserved.
+
+You can run `reekup` multiple times in the same project, keeping your `config.reek` file up to date with ASR's standard.
+
+## Development
+
+- [Install Rust](https://www.rust-lang.org/en-US/)
+- Clone this repo
+- `cd reekup`
+- `./script/setup`
+- `./script/test`
+    - Note, tests are run with `RUST_TEST_THREADS=1` to remove parallelization.
+    - Running the `tests/reekup.rs` tests in parallel leads to random failure due to the tests all trying to write to & delete the same file.

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# script/bootstrap: Resolve all dependencies that the application requires to
+#                   run.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ -f ".overcommit.yml" ]; then
+echo "==> Installing Overcommit hooks…"
+overcommit
+overcommit --sign
+fi

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# script/setup: Resolve all dependencies that the application requires to
+#                   run.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+script/bootstrap
+cargo check

--- a/script/test
+++ b/script/test
@@ -1,0 +1,2 @@
+  script/update
+  RUST_TEST_THREADS=1 cargo test

--- a/script/update
+++ b/script/update
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# script/update: Update application to run for its current checkout.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+script/setup
+cargo update

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,80 @@
+extern crate curl;
+use std::io::Write;
+use std::fs::OpenOptions;
+use std::fs;
+
+use self::curl::easy::Easy;
+
+use std::io::BufReader;
+use std::io::BufRead;
+
+pub fn run() {
+    // Prepare the HTTP request to be sent.
+    let mut req = Easy::new();
+    req.get(true).unwrap();
+    req.url("https://raw.githubusercontent.com/umn-asr/dotfiles/master/reek").unwrap();
+
+    // This is called when the request is complete. It opens (or creates) config.reek and is set to
+    // append at the bottom of the file.
+    req.write_function(|data| {
+            let temp = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .open("reekup.tmp");
+
+            let mut temp = match temp {
+                Ok(c) => c,
+                Err(e) => panic!(e),
+            };
+
+            let current = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .open("config.reek");
+
+            let current = match current {
+                Ok(c) => c,
+                Err(e) => panic!(e),
+            };
+
+            let current_buffer = BufReader::new(&current);
+
+            let mut copy_line = true;
+
+            for line in current_buffer.lines() {
+                let l = line.unwrap();
+
+                if l == "### Reekup Begin" {
+                    copy_line = false;
+                }
+
+                if copy_line {
+                    write!(&mut temp, "{}\n", l).unwrap();
+                }
+
+                if l == "### Reekup End" {
+                    copy_line = true;
+                }
+
+            }
+            write!(&mut temp, "### Reekup Begin\n").unwrap();
+            temp.write_all(data).unwrap();
+            write!(&mut temp, "### Reekup End\n").unwrap();
+
+            fs::copy("reekup.tmp", "config.reek").unwrap();
+
+            fs::remove_file("reekup.tmp").unwrap();
+
+            Ok(data.len())
+        })
+        .unwrap();
+
+    req.perform().unwrap();
+
+    // If the request runs, do nothing. Otherwise display a generic error.
+    match req.response_code() {
+        Ok(_) => (),
+        Err(_) => println!("Unable to make http request"),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,4 @@
-extern crate curl;
-extern crate futures;
-extern crate tokio_core;
-extern crate tokio_curl;
-
-use std::io::Write;
-use std::fs::OpenOptions;
-use std::fs;
-
-use curl::easy::Easy;
-use tokio_core::reactor::Core;
-use tokio_curl::Session;
-
-use std::io::BufReader;
-use std::io::BufRead;
+extern crate reekup;
 
 #[macro_use]
 extern crate clap;
@@ -21,84 +7,5 @@ use clap::App;
 fn main() {
     let yml = load_yaml!("cli.yml");
     let matches = App::from_yaml(yml).get_matches();
-    update_reek_config();
-}
-
-fn update_reek_config() {
-    // Create an event loop that we'll run on, as well as an HTTP `Session`
-    // which we'll be routing all requests through.
-    let mut lp = Core::new().unwrap();
-    let session = Session::new(lp.handle());
-
-
-    // Prepare the HTTP request to be sent.
-    let mut req = Easy::new();
-    req.get(true).unwrap();
-    req.url("https://raw.githubusercontent.com/umn-asr/dotfiles/master/reek").unwrap();
-
-    // This is called when the request is complete. It opens (or creates) config.reek and is set to
-    // append at the bottom of the file.
-    req.write_function(|data| {
-            let temp = OpenOptions::new()
-                .write(true)
-                .create(true)
-                .open("reekup.tmp");
-
-            let mut temp = match temp {
-                Ok(c) => c,
-                Err(e) => panic!(e),
-            };
-
-            let current = OpenOptions::new()
-                .read(true)
-                .write(true)
-                .create(true)
-                .open("config.reek");
-
-            let current = match current {
-                Ok(c) => c,
-                Err(e) => panic!(e),
-            };
-
-            let current_buffer = BufReader::new(&current);
-
-            let mut copy_line = true;
-
-            for line in current_buffer.lines() {
-                let l = line.unwrap();
-
-                if l == "### Reekup Begin" {
-                    copy_line = false;
-                }
-
-                if copy_line {
-                    write!(&mut temp, "{}\n", l).unwrap();
-                }
-
-                if l == "### Reekup End" {
-                    copy_line = true;
-                }
-
-            }
-            write!(&mut temp, "### Reekup Begin\n").unwrap();
-            temp.write_all(data).unwrap();
-            write!(&mut temp, "### Reekup End\n").unwrap();
-
-            fs::copy("reekup.tmp", "config.reek").unwrap();
-
-            fs::remove_file("reekup.tmp").unwrap();
-
-            Ok(data.len())
-        })
-        .unwrap();
-
-    // Once we've got our session, issue an HTTP request to download the
-    // rust-lang home page
-    let request = session.perform(req);
-
-    // If the request runs, do nothing. Otherwise display a generic error.
-    match lp.run(request) {
-        Ok(_) => (),
-        Err(_) => println!("Unable to make http request"),
-    }
+    reekup::run();
 }

--- a/tests/reekup.rs
+++ b/tests/reekup.rs
@@ -1,0 +1,50 @@
+extern crate reekup;
+
+use std::fs::File;
+use std::fs;
+use std::io::BufReader;
+use std::io::BufRead;
+use std::io::Write;
+
+#[test]
+fn it_creates_a_config_reek_file() {
+    assert!(File::open("config.reek").is_err());
+    reekup::run();
+    assert!(File::open("config.reek").is_ok());
+
+    cleanup();
+}
+
+#[test]
+fn running_twice_does_not_add_config_twice() {
+    reekup::run();
+    let file = File::open("config.reek").unwrap();
+    let line_count = BufReader::new(&file).lines().count();
+
+    reekup::run();
+
+    let updated_file = File::open("config.reek").unwrap();
+    assert_eq!(line_count, BufReader::new(&updated_file).lines().count());
+
+    cleanup();
+}
+
+#[test]
+fn custom_contents_are_not_lost() {
+    reekup::run();
+
+    let mut file = File::create("config.reek").unwrap();
+    write!(&mut file, "{}\n", "Custom Config").unwrap();
+
+    reekup::run();
+
+    let updated_file = File::open("config.reek").unwrap();
+
+    assert!(BufReader::new(&updated_file).lines().any(|l| l.unwrap() == "Custom Config"));
+
+    cleanup();
+}
+
+fn cleanup() {
+    fs::remove_file("config.reek").unwrap();
+}


### PR DESCRIPTION
The final piece for 0.2.0 is adding tests to cover the documented usage,
which this does.

To make the testing easier I've split the actual meat of the code into
library file. This lets me test the `run` method directly. I could not
figure out how to test the code via `main`, and it seemed like doing so
wouldn't have been a good idea anyway.

During this move I pulled out Tokio. I think it's overkill for this. I
also thought it was causing testing problems, though it probably wasn't.
Testing problems or no, we don't need an async http core to this dumb
little app that downloads a single file from GitHub. I can do that with
just the `curl` crate.

Something I learned while writing tests, by default Rust parallellizes
its tests. Great! Except when you have three tests that are all trying
to write/read/delete the same file. So, dumb design on my part but I'm
fixing it for now by turning off test parallellization. If you run
`./script/test` everything is run in a single thread.

I've also added some other helper scripts and documented their usage in
the README.