### PR TITLE
Rough implementation of config flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,9 +1,10 @@
 [root]
 name = "reekup"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap 2.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ authors = ["Ian Whitney <whit0694@umn.edu>"]
 [dependencies]
 curl = "0.4.6"
 clap = {version = "2", features = ["yaml"]}
+yaml-rust = "*"

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -17,3 +17,8 @@ args:
       value_name: URL
       help: URL to get your standard Reek config file from
       default_value: "https://raw.githubusercontent.com/umn-asr/dotfiles/master/reek"
+  - config:
+      short: c
+      long: config
+      value_name: FILE
+      help: YAML file that contains your reekup config

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -1,0 +1,41 @@
+extern crate clap;
+extern crate yaml_rust;
+
+use std::fs::File;
+use std::io::Read;
+use self::yaml_rust::YamlLoader;
+
+#[derive(Debug)]
+pub struct ConfigFile {
+    pub target_filepath: String,
+    pub source_url: String,
+}
+
+impl ConfigFile {
+    pub fn from_args(args: &clap::ArgMatches) -> Option<Self> {
+        if let Some(config_file) = args.value_of("config") {
+            let x = File::open(&config_file);
+
+            if x.is_err() {
+                panic!("Config file does not exist")
+            } else {
+                let mut f = File::open(&config_file).unwrap();
+                let mut buffer = String::new();
+                f.read_to_string(&mut buffer).unwrap();
+                let conf = YamlLoader::load_from_str(&buffer).unwrap();
+
+                let doc = &conf[0];
+
+                let target = String::from(doc["out"].as_str().unwrap());
+                let url = String::from(doc["url"].as_str().unwrap());
+
+                Some(ConfigFile {
+                    target_filepath: target,
+                    source_url: url,
+                })
+            }
+        } else {
+            None
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ use std::fs::File;
 use std::fs::OpenOptions;
 
 pub mod options;
+pub mod config_file;
+
 use self::options::Options;
 
 pub fn run(options: &Options) {

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,4 +1,7 @@
 extern crate clap;
+extern crate yaml_rust;
+
+use config_file::ConfigFile;
 
 #[derive(Debug)]
 pub struct Options {
@@ -8,9 +11,16 @@ pub struct Options {
 
 impl Options {
     pub fn from_args(args: &clap::ArgMatches) -> Self {
-        Options {
-            target_filepath: String::from(args.value_of("out").unwrap()),
-            source_url: String::from(args.value_of("url").unwrap()),
+        if let Some(config_file) = ConfigFile::from_args(&args) {
+            Options {
+                target_filepath: config_file.target_filepath,
+                source_url: config_file.source_url,
+            }
+        } else {
+            Options {
+                target_filepath: String::from(args.value_of("out").unwrap()),
+                source_url: String::from(args.value_of("url").unwrap()),
+            }
         }
     }
 }

--- a/tests/examples/.reekup.config.yml
+++ b/tests/examples/.reekup.config.yml
@@ -1,0 +1,3 @@
+---
+out: myconfig.reek
+url: https://raw.githubusercontent.com/umn-asr/reekup/master/tests/examples/reekup_test.reek

--- a/tests/reekup.rs
+++ b/tests/reekup.rs
@@ -139,6 +139,20 @@ fn standard_config_can_be_retrieved_from_a_url() {
     cleanup("asr_defaults.reek");
 }
 
+#[test]
+fn cli_can_use_a_provided_config_file_to_control_output_and_url() {
+    Command::new("./target/debug/reekup")
+        .args(&["--config", "tests/examples/.reekup.config.yml"])
+        .output()
+        .expect("failed to execute");
+
+    assert!(fs::metadata("myconfig.reek").is_ok());
+    let myconfig_reek = File::open("myconfig.reek").unwrap();
+    assert!(BufReader::new(&myconfig_reek).lines().any(|l| l.unwrap() == "  - reekup_test_config"));
+
+    cleanup("myconfig.reek");
+}
+
 fn cleanup(file_name: &str) {
     fs::remove_file(file_name).unwrap();
 }


### PR DESCRIPTION
Closes #17

Right now the expectation is that the config file provides both the url
and out configuration. If it does not, reekup will fail. We'll fix that
later, see #18